### PR TITLE
Feat: viewModel, event

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,9 @@
 
 `2023-01-05`  
 - view 구조 설정
-
+- dynamic하게 category 호출
+- EventFlow 추가
+- repeatOnLifeCycle 추가 
 
 
 </details>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -6,6 +6,7 @@
     <uses-permission android:name="android.permission.INTERNET"/>
 
     <application
+        android:name=".HomeApplication"
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"

--- a/app/src/main/java/com/example/afreecasampleapp/MainActivity.kt
+++ b/app/src/main/java/com/example/afreecasampleapp/MainActivity.kt
@@ -6,7 +6,9 @@ import androidx.activity.viewModels
 import androidx.databinding.DataBindingUtil
 import com.example.afreecasampleapp.databinding.ActivityMainBinding
 import com.example.afreecasampleapp.viewmodels.AfreecaTvViewModel
+import dagger.hilt.android.AndroidEntryPoint
 
+@AndroidEntryPoint
 class MainActivity : AppCompatActivity() {
     lateinit var binding : ActivityMainBinding
     val viewModel : AfreecaTvViewModel by viewModels()

--- a/app/src/main/java/com/example/afreecasampleapp/ViewPagerHomeFragment.kt
+++ b/app/src/main/java/com/example/afreecasampleapp/ViewPagerHomeFragment.kt
@@ -8,13 +8,18 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.activityViewModels
 import com.example.afreecasampleapp.adapters.ViewPagerAdapter
+import com.example.afreecasampleapp.data.BroadCategory
 import com.example.afreecasampleapp.databinding.FragmentViewPagerHomeBinding
+import com.example.afreecasampleapp.utility.event.repeatOnStarted
 import com.example.afreecasampleapp.viewmodels.AfreecaTvViewModel
 import com.google.android.material.tabs.TabLayoutMediator
+
+import kotlinx.coroutines.flow.collectLatest
 
 class ViewPagerHomeFragment : Fragment() {
 
     lateinit var mainActivity : MainActivity
+    lateinit var binding : FragmentViewPagerHomeBinding
     val viewModel : AfreecaTvViewModel by activityViewModels()
 
     override fun onAttach(context: Context) {
@@ -31,24 +36,40 @@ class ViewPagerHomeFragment : Fragment() {
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
-        val binding = FragmentViewPagerHomeBinding.inflate(inflater, container, false)
+        binding = FragmentViewPagerHomeBinding.inflate(inflater, container, false)
         binding.viewPagerHome.adapter = ViewPagerAdapter(this)
-
-        TabLayoutMediator(binding.tabar, binding.viewPagerHome) { tab, position ->
-            tab.text = getTabTitle(position)
-        }.attach()
-
         return binding.root
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        repeatOnStarted {
+            viewModel.broadData.collectLatest { event ->
+                //binding.progressBarMountain.visibility = View.VISIBLE
+                handleEvent(event)
+            }
+        }
 
+        viewModel.getCategories()
     }
+
+    private fun setAdapterText(categories : List<BroadCategory>){
+        TabLayoutMediator(binding.tabar, binding.viewPagerHome) { tab, position ->
+            tab.text = getTabTitle(position)
+        }.attach()
+    }
+
+
 
     private fun getTabTitle(position: Int): String? {
         return when (position) {
+            position -> viewModel.categoryInfo[position].cate_name
             else -> null
         }
+    }
+
+    fun handleEvent(event: AfreecaTvViewModel.Event) = when (event) {
+        is AfreecaTvViewModel.Event.BroadCategories -> setAdapterText(event.mountains)
+        else ->{}
     }
 }

--- a/app/src/main/java/com/example/afreecasampleapp/api/AfreecaTvApiService.kt
+++ b/app/src/main/java/com/example/afreecasampleapp/api/AfreecaTvApiService.kt
@@ -15,13 +15,13 @@ interface AfreecaTvApiService {
     @GET("broad/list")
     suspend fun broadList(
         @Query("client_id") clientId: String = "af_mobilelab_dev_e0f147f6c034776add2142b425e81777",
-        @Query("locale") locale: String = "ko_KR"
+        @Query("select_value") select_value : Int
     ): AfreecaBroadListResponse
 
     @GET("broad/category/list")
     suspend fun broadCategoryList(
         @Query("client_id") clientId: String = "af_mobilelab_dev_e0f147f6c034776add2142b425e81777",
-        @Query("select_value") select_value : Int
+        @Query("locale") locale: String = "ko_KR"
     ): AfreecaBroadCategoryListResponse
 
     companion object {

--- a/app/src/main/java/com/example/afreecasampleapp/data/repository/AfreecaTvRepository.kt
+++ b/app/src/main/java/com/example/afreecasampleapp/data/repository/AfreecaTvRepository.kt
@@ -1,11 +1,17 @@
 package com.example.afreecasampleapp.data.repository
 
 import com.example.afreecasampleapp.api.AfreecaTvApiService
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOn
+import java.util.concurrent.Flow
 import javax.inject.Inject
 
 class AfreecaTvRepository@Inject constructor(private val service: AfreecaTvApiService) {
 
-
+    fun getCategories() = flow{
+        emit(service.broadCategoryList().broad_category)
+    }.flowOn(Dispatchers.IO)
 
     companion object {
         private const val PAGE_SIZE = 20

--- a/app/src/main/java/com/example/afreecasampleapp/viewmodels/AfreecaTvViewModel.kt
+++ b/app/src/main/java/com/example/afreecasampleapp/viewmodels/AfreecaTvViewModel.kt
@@ -1,5 +1,7 @@
 package com.example.afreecasampleapp.viewmodels
 
+import android.util.Log
+import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.paging.PagingData
@@ -10,19 +12,35 @@ import com.example.afreecasampleapp.utility.event.MutableEventFlow
 import com.example.afreecasampleapp.utility.event.asEventFlow
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
 class AfreecaTvViewModel @Inject constructor(
-    private val repository: AfreecaTvRepository
+    private val repository: AfreecaTvRepository,
+    private val savedStateHandle: SavedStateHandle
 ) : ViewModel() {
 
     private val _broadData = MutableEventFlow<Event>()
     val broadData = _broadData.asEventFlow()
 
+    var categoryInfo = ArrayList<BroadCategory>()
+
+    fun getCategories(){
+        viewModelScope.launch {
+            repository.getCategories().collectLatest {
+                categoryInfo = it as ArrayList<BroadCategory>
+                _broadData.emit(Event.BroadCategories(it))
+            }
+        }
+    }
 
 
     sealed class Event {
-        data class BroadCategories(val mountains : ArrayList<BroadCategory>) : Event()
+        data class BroadCategories(val mountains : List<BroadCategory>) : Event()
+        data class BroadLists(val mountains : ArrayList<Broad>) : Event()
     }
+
 }


### PR DESCRIPTION
소비되지 않은 event를 가지고 있기 위해 EventFlow 추가
background에서 쓸데 없는 UI 업데이트를 막기 위해 repeatOnLifeCycle 추가 
category를 api 결과에 맞춰 보여주기 위해 Fragment & 이름 수정